### PR TITLE
Add react-fontawesome to the Project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -933,6 +933,51 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.27.tgz",
+      "integrity": "sha512-97GaByGaXDGMkzcJX7VmR/jRJd8h1mfhtA7RsxDBN61GnWE/PPCZhOdwG/8OZYktiRUF0CvFOr+VgRkJrt6TWg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.27",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.27.tgz",
+      "integrity": "sha512-sOD3DKynocnHYpuw2sLPnTunDj7rLk91LYhi2axUYwuGe9cPCw7Bsu9EWtVdNJP+IYgTCZIbyARKXuy5K/nv+Q==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.27"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.12.1.tgz",
+      "integrity": "sha512-IYUYcgGsQuwiIHjRGfeSTCIQKUSZMb6FsV6mDj78K0D+YzGJkM4cvEBBUMHtnla5D2HCxncMI/9JX5YIk2GHeQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.27"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.12.1.tgz",
+      "integrity": "sha512-bGda18seHXb+24K6DPUFzqn4kG7B+JViP/BscMcNUXvT00M86xNhdgP2TXSdflQXn53QWqymKjx/8rhaDOJyhA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.27"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.12.1.tgz",
+      "integrity": "sha512-k3MwRFFUhyL4cuCJSaHDA0YNYMELDXX0h8JKtWYxO5XD3Dn+maXOMrVAAiNGooUyM2v/wz/TOaM0jxYVKeXX7g==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.27"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.9.tgz",
+      "integrity": "sha512-49V3WNysLZU5fZ3sqSuys4nGRytsrxJktbv3vuaXkEoxv22C6T7TEG0TW6+nqVjMnkfCQd5xOnmJoZHMF78tOw==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.27",
+    "@fortawesome/free-brands-svg-icons": "^5.12.1",
+    "@fortawesome/free-regular-svg-icons": "^5.12.1",
+    "@fortawesome/free-solid-svg-icons": "^5.12.1",
+    "@fortawesome/react-fontawesome": "^0.1.9",
     "bootstrap": "^4.4.1",
     "gatsby": "^2.19.45",
     "gatsby-image": "^2.2.44",

--- a/src/helpers/fontawesomeicons.js
+++ b/src/helpers/fontawesomeicons.js
@@ -1,0 +1,7 @@
+import { faCheckSquare, faCoffee, faCar } from '@fortawesome/free-solid-svg-icons'
+
+export const fontAwesomeIcons = {
+   faCoffee,
+   faCheckSquare,
+   faCar
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,7 +4,12 @@ import { Link } from "gatsby"
 import Layout from "../components/layout"
 import Image from "../components/image"
 import SEO from "../components/seo"
+import { fontAwesomeIcons } from '../helpers/fontawesomeicons'
 import 'bootstrap/dist/css/bootstrap.min.css';
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { fab } from '@fortawesome/free-brands-svg-icons'
+
+library.add(fab, fontAwesomeIcons)
 
 const IndexPage = () => (
   <Layout>


### PR DESCRIPTION
This adds FontAwesome support to the project. The fontawesomeicons.js file includes some sample fontawesome icons. Whenever we need we will have to import the icons there before using it in the file.

Fixes #9