### PR TITLE
Display navigation bar correctly for iPhone 5

### DIFF
--- a/src/components/jumbotron.js
+++ b/src/components/jumbotron.js
@@ -34,7 +34,6 @@ const JumbotronElement = () => {
                 <Carousel>
                     <Carousel.Item>
                         <Img
-                            className="d-block w-100"
                             fluid={query.image1.childImageSharp.fluid}
                             alt={query.image1.relativePath}
                         />
@@ -45,7 +44,6 @@ const JumbotronElement = () => {
                     </Carousel.Item>
                     <Carousel.Item>
                         <Img
-                            className="d-block w-100"
                             fluid={query.image2.childImageSharp.fluid}
                             alt={query.image2.relativePath}
                         />
@@ -56,7 +54,6 @@ const JumbotronElement = () => {
                     </Carousel.Item>
                     <Carousel.Item>
                         <Img
-                            className="d-block w-100"
                             fluid={query.image3.childImageSharp.fluid}
                             alt={query.image3.relativePath}
                         />

--- a/src/components/nav-bar.js
+++ b/src/components/nav-bar.js
@@ -15,7 +15,7 @@ const NavBar = ({ siteTitle, location }) => {
                     <img
                         src={logo}
                         className="d-inline-block align-top mb-0"
-                        width="250"
+                        width="210"
                         alt={siteTitle + " Logo"}
                     />
                 </Link>


### PR DESCRIPTION
The navigation bar breaks to two lines in iPhone5 xm screen sizes. This fixes that problem.

Fixes #90